### PR TITLE
fix(rclone): change --dir-cache-time=10s

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -785,7 +785,7 @@ ExecStart=/usr/bin/rclone mount \\
   --allow-other \\
   --poll-interval 60s \\
   --vfs-cache-poll-interval 30s \\
-  --dir-cache-time=120s \\
+  --dir-cache-time=10s \\
   --exclude="**sample**" \\
 EOF
 


### PR DESCRIPTION
--dir-cache-time=120s will cause a 2 min delay in finding recently added debrid content. Using --dir-cache-time=10s will significantly reduce the delay.